### PR TITLE
Fix invalid string input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '1.8', '11', '17' ]
+        java: [ '11', '17' ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
     </distributionManagement>
 
     <properties>
-        <javadocSource>7</javadocSource>
-        <jdkTarget>1.7</jdkTarget>
+        <javadocSource>8</javadocSource>
+        <jdkTarget>8</jdkTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j-version>1.6.1</slf4j-version>
         <project.build.outputTimestamp>2021-10-14T05:42:06Z</project.build.outputTimestamp>
@@ -165,25 +165,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <release>${jdkTarget}</release>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <source>${jdkTarget}</source>
-                            <target>${jdkTarget}</target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,38 +31,8 @@
     <name>Jansi</name>
     <description>Jansi is a java library for generating and interpreting ANSI escape sequences.</description>
 
-    <properties>
-        <javadocSource>7</javadocSource>
-        <jdkTarget>1.7</jdkTarget>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j-version>1.6.1</slf4j-version>
-        <project.build.outputTimestamp>2021-10-14T05:42:06Z</project.build.outputTimestamp>
-    </properties>
-
     <url>http://fusesource.github.io/jansi</url>
     <inceptionYear>2009</inceptionYear>
-
-    <issueManagement>
-        <system>jira</system>
-        <url>https://github.com/fusesource/jansi/issues</url>
-    </issueManagement>
-
-    <mailingLists>
-        <mailingList>
-            <name>Discussion List</name>
-            <archive>http://groups.google.com/group/jansi</archive>
-            <post>jansi-dev@googlegroups.com</post>
-            <subscribe>jansi-dev+subscribe@googlegroups.com</subscribe>
-            <unsubscribe>jansi-dev+unsubscribe@googlegroups.com</unsubscribe>
-        </mailingList>
-        <mailingList>
-            <name>Commits and Issue Tracker List</name>
-            <archive>http://groups.google.com/group/jansi-commits</archive>
-            <post>jansi-commits@googlegroups.com</post>
-            <subscribe>jansi-commits+subscribe@googlegroups.com</subscribe>
-            <unsubscribe>jansi-commisots+unsubscribe@googlegroups.com</unsubscribe>
-        </mailingList>
-    </mailingLists>
 
     <licenses>
         <license>
@@ -71,37 +41,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
-    <scm>
-        <url>https://github.com/fusesource/jansi</url>
-        <connection>scm:git:git://github.com/fusesource/jansi.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/fusesource/jansi.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
-
-    <distributionManagement>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Staging Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <developers>
         <developer>
@@ -119,26 +58,101 @@
         </developer>
     </developers>
 
+    <mailingLists>
+        <mailingList>
+            <name>Discussion List</name>
+            <subscribe>jansi-dev+subscribe@googlegroups.com</subscribe>
+            <unsubscribe>jansi-dev+unsubscribe@googlegroups.com</unsubscribe>
+            <post>jansi-dev@googlegroups.com</post>
+            <archive>http://groups.google.com/group/jansi</archive>
+        </mailingList>
+        <mailingList>
+            <name>Commits and Issue Tracker List</name>
+            <subscribe>jansi-commits+subscribe@googlegroups.com</subscribe>
+            <unsubscribe>jansi-commisots+unsubscribe@googlegroups.com</unsubscribe>
+            <post>jansi-commits@googlegroups.com</post>
+            <archive>http://groups.google.com/group/jansi-commits</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <connection>scm:git:git://github.com/fusesource/jansi.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/fusesource/jansi.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/fusesource/jansi</url>
+    </scm>
+
+    <issueManagement>
+        <system>jira</system>
+        <url>https://github.com/fusesource/jansi/issues</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Sonatype Staging Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <properties>
+        <javadocSource>7</javadocSource>
+        <jdkTarget>1.7</jdkTarget>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j-version>1.6.1</slf4j-version>
+        <project.build.outputTimestamp>2021-10-14T05:42:06Z</project.build.outputTimestamp>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli-codegen</artifactId>
+            <version>4.5.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.fusesource.mvnplugins</groupId>
-                <artifactId>fuse-jxr-skin</artifactId>
-                <version>1.9</version>
-            </extension>
-        </extensions>
 
         <resources>
             <resource>
-                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <directory>src/main/resources</directory>
                 <includes>
                     <include>**/*.properties</include>
                 </includes>
             </resource>
             <resource>
-                <directory>src/main/resources</directory>
                 <filtering>false</filtering>
+                <directory>src/main/resources</directory>
                 <excludes>
                     <exclude>**/*.properties</exclude>
                 </excludes>
@@ -178,18 +192,16 @@
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
+                        <phase>process-classes</phase>
                         <configuration>
                             <instructions>
                                 <Main-Class>org.fusesource.jansi.AnsiMain</Main-Class>
-                                <Export-Package>
-                                    !org.fusesource.jansi.internal.native.*;
+                                <Export-Package>!org.fusesource.jansi.internal.native.*;
                                     org.fusesource.jansi.*;
-                                    -noimport:=true
-                                </Export-Package>
+                                    -noimport:=true</Export-Package>
                                 <_removeheaders>Bnd-LastModified,Include-Resource,Private-Package,Originally-Created-By</_removeheaders>
                                 <_reproducible>true</_reproducible>
                             </instructions>
@@ -204,19 +216,17 @@
                 <executions>
                     <execution>
                         <id>add-module-infos</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>add-module-info</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <jvmVersion>9</jvmVersion>
                             <module>
                                 <moduleInfo>
                                     <name>org.fusesource.jansi</name>
-                                    <exports>
-                                        org.fusesource.jansi;
-                                        org.fusesource.jansi.io;
-                                    </exports>
+                                    <exports>org.fusesource.jansi;
+                                        org.fusesource.jansi.io;</exports>
                                 </moduleInfo>
                             </module>
                         </configuration>
@@ -228,13 +238,20 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>info.picocli</groupId>
+                        <artifactId>picocli-codegen</artifactId>
+                        <version>4.5.2</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>generate-graalvm-info</id>
-                        <phase>process-classes</phase>
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <phase>process-classes</phase>
                         <configuration>
                             <includeProjectDependencies>true</includeProjectDependencies>
                             <classpathScope>test</classpathScope>
@@ -251,13 +268,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>info.picocli</groupId>
-                        <artifactId>picocli-codegen</artifactId>
-                        <version>4.5.2</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -338,10 +348,10 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -408,27 +418,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.fusesource.mvnplugins</groupId>
+                <artifactId>fuse-jxr-skin</artifactId>
+                <version>1.9</version>
+            </extension>
+        </extensions>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli-codegen</artifactId>
-            <version>4.5.2</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,58 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.38.0</version>
+                <configuration>
+                    <java>
+                        <toggleOffOn />
+                        <palantirJavaFormat>
+                            <version>2.35.0</version>
+                        </palantirJavaFormat>
+                        <importOrder>
+                            <order>java|javax,org,,\#</order>
+                        </importOrder>
+                        <removeUnusedImports />
+                        <licenseHeader>
+                            <content>/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */</content>
+                        </licenseHeader>
+                    </java>
+                    <pom>
+                        <sortPom>
+                            <expandEmptyElements>false</expandEmptyElements>
+                            <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                        </sortPom>
+                    </pom>
+                    <upToDateChecking>
+                        <enabled>true</enabled>
+                    </upToDateChecking>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/src/main/java/org/fusesource/jansi/Ansi.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Callable;
  * Provides a fluent API for generating
  * <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences">ANSI escape sequences</a>.
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @since 1.0
  */
 public class Ansi implements Appendable {

--- a/src/main/java/org/fusesource/jansi/Ansi.java
+++ b/src/main/java/org/fusesource/jansi/Ansi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,6 @@ public class Ansi implements Appendable {
         public int value() {
             return value;
         }
-
     }
 
     /**
@@ -215,8 +214,7 @@ public class Ansi implements Appendable {
         }
     }
 
-    private static class NoAnsi
-            extends Ansi {
+    private static class NoAnsi extends Ansi {
         public NoAnsi() {
             super();
         }
@@ -900,8 +898,7 @@ public class Ansi implements Appendable {
     }
 
     private void flushAttributes() {
-        if (attributeOptions.isEmpty())
-            return;
+        if (attributeOptions.isEmpty()) return;
         if (attributeOptions.size() == 1 && attributeOptions.get(0) == 0) {
             builder.append(FIRST_ESC_CHAR);
             builder.append(SECOND_ESC_CHAR);

--- a/src/main/java/org/fusesource/jansi/AnsiColors.java
+++ b/src/main/java/org/fusesource/jansi/AnsiColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package org.fusesource.jansi;
  * @since 2.1
  */
 public enum AnsiColors {
-
     Colors16("16 colors"),
     Colors256("256 colors"),
     TrueColor("24-bit colors");

--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -51,7 +51,6 @@ import static org.fusesource.jansi.internal.Kernel32.SetConsoleMode;
  * <p>The native library used is named <code>jansi</code> and is loaded using <a href="http://fusesource.github.io/hawtjni/">HawtJNI</a> Runtime
  * <a href="http://fusesource.github.io/hawtjni/documentation/api/index.html?org/fusesource/hawtjni/runtime/Library.html"><code>Library</code></a>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @since 1.0
  * @see #systemInstall()
  * @see #out()

--- a/src/main/java/org/fusesource/jansi/AnsiConsole.java
+++ b/src/main/java/org/fusesource/jansi/AnsiConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,24 +28,24 @@ import java.util.Locale;
 
 import org.fusesource.jansi.internal.CLibrary;
 import org.fusesource.jansi.internal.CLibrary.WinSize;
+import org.fusesource.jansi.internal.Kernel32.CONSOLE_SCREEN_BUFFER_INFO;
 import org.fusesource.jansi.io.AnsiOutputStream;
 import org.fusesource.jansi.io.AnsiProcessor;
 import org.fusesource.jansi.io.FastBufferedOutputStream;
 import org.fusesource.jansi.io.WindowsAnsiProcessor;
-import org.fusesource.jansi.internal.Kernel32.CONSOLE_SCREEN_BUFFER_INFO;
 
 import static org.fusesource.jansi.internal.CLibrary.ioctl;
 import static org.fusesource.jansi.internal.CLibrary.isatty;
 import static org.fusesource.jansi.internal.Kernel32.GetConsoleMode;
+import static org.fusesource.jansi.internal.Kernel32.GetConsoleScreenBufferInfo;
 import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
 import static org.fusesource.jansi.internal.Kernel32.STD_ERROR_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleMode;
-import static org.fusesource.jansi.internal.Kernel32.GetConsoleScreenBufferInfo;
 
 /**
  * Provides consistent access to an ANSI aware console PrintStream or an ANSI codes stripping PrintStream
- * if not on a terminal (see 
+ * if not on a terminal (see
  * <a href="http://fusesource.github.io/jansi/documentation/native-api/index.html?org/fusesource/jansi/internal/CLibrary.html">Jansi native
  * CLibrary isatty(int)</a>).
  * <p>The native library used is named <code>jansi</code> and is loaded using <a href="http://fusesource.github.io/hawtjni/">HawtJNI</a> Runtime
@@ -203,26 +203,24 @@ public class AnsiConsole {
         return w;
     }
 
-    static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    static final boolean IS_WINDOWS =
+            System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    static final boolean IS_CYGWIN = IS_WINDOWS
-            && System.getenv("PWD") != null
-            && System.getenv("PWD").startsWith("/");
+    static final boolean IS_CYGWIN =
+            IS_WINDOWS && System.getenv("PWD") != null && System.getenv("PWD").startsWith("/");
 
     static final boolean IS_MSYSTEM = IS_WINDOWS
             && System.getenv("MSYSTEM") != null
             && (System.getenv("MSYSTEM").startsWith("MINGW")
-                || System.getenv("MSYSTEM").equals("MSYS"));
+                    || System.getenv("MSYSTEM").equals("MSYS"));
 
-    static final boolean IS_CONEMU = IS_WINDOWS
-            && System.getenv("ConEmuPID") != null;
+    static final boolean IS_CONEMU = IS_WINDOWS && System.getenv("ConEmuPID") != null;
 
     static final int ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
 
     static int STDOUT_FILENO = 1;
 
     static int STDERR_FILENO = 2;
-
 
     static {
         if (getBoolean(JANSI_EAGER)) {
@@ -234,8 +232,7 @@ public class AnsiConsole {
     private static int installed;
     private static int virtualProcessing;
 
-    private AnsiConsole() {
-    }
+    private AnsiConsole() {}
 
     private static AnsiPrintStream ansiStream(boolean stdout) {
         FileDescriptor descriptor = stdout ? FileDescriptor.out : FileDescriptor.err;
@@ -277,13 +274,11 @@ public class AnsiConsole {
             type = withException ? AnsiType.Unsupported : AnsiType.Redirected;
             installer = uninstaller = null;
             width = new AnsiOutputStream.ZeroWidthSupplier();
-        }
-        else if (IS_WINDOWS) {
+        } else if (IS_WINDOWS) {
             final long console = GetStdHandle(stdout ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
             final int[] mode = new int[1];
             final boolean isConsole = GetConsoleMode(console, mode) != 0;
-            if (isConsole
-                    && SetConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0) {
+            if (isConsole && SetConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0) {
                 SetConsoleMode(console, mode[0]); // set it back for now, but we know it works
                 processor = null;
                 type = AnsiType.VirtualTerminal;
@@ -302,15 +297,14 @@ public class AnsiConsole {
                         }
                     }
                 };
-            }
-            else if ((IS_CONEMU || IS_CYGWIN || IS_MSYSTEM) && !isConsole) {
+            } else if ((IS_CONEMU || IS_CYGWIN || IS_MSYSTEM) && !isConsole) {
                 // ANSI-enabled ConEmu, Cygwin or MSYS(2) on Windows...
                 processor = null;
                 type = AnsiType.Native;
                 installer = uninstaller = null;
-            }
-            else {
-                // On Windows, when no ANSI-capable terminal is used, we know the console does not natively interpret ANSI
+            } else {
+                // On Windows, when no ANSI-capable terminal is used, we know the console does not natively interpret
+                // ANSI
                 // codes but we can use jansi Kernel32 API for console
                 AnsiProcessor proc;
                 AnsiType ttype;
@@ -381,9 +375,7 @@ public class AnsiConsole {
         // the ansi escapes for piping it into ansi color aware commands (e.g. less -r)
         else if (getBoolean(JANSI_FORCE)) {
             mode = AnsiMode.Force;
-        }
-
-        else {
+        } else {
             mode = isatty ? AnsiMode.Default : AnsiMode.Strip;
         }
 
@@ -391,7 +383,8 @@ public class AnsiConsole {
 
         String colorterm, term;
         // If the jansi.colors property is set, use it
-        String jansiColors = System.getProperty(stdout ? JANSI_OUT_COLORS : JANSI_ERR_COLORS, System.getProperty(JANSI_COLORS));
+        String jansiColors =
+                System.getProperty(stdout ? JANSI_OUT_COLORS : JANSI_ERR_COLORS, System.getProperty(JANSI_COLORS));
         if (JANSI_COLORS_TRUECOLOR.equals(jansiColors)) {
             colors = AnsiColors.TrueColor;
         } else if (JANSI_COLORS_256.equals(jansiColors)) {
@@ -433,8 +426,10 @@ public class AnsiConsole {
             } catch (UnsupportedCharsetException e) {
             }
         }
-        return newPrintStream(new AnsiOutputStream(out, width, mode, processor, type, colors, cs,
-                installer, uninstaller, resetAtUninstall), cs.name());
+        return newPrintStream(
+                new AnsiOutputStream(
+                        out, width, mode, processor, type, colors, cs, installer, uninstaller, resetAtUninstall),
+                cs.name());
     }
 
     private static AnsiPrintStream newPrintStream(AnsiOutputStream out, String enc) {
@@ -507,7 +502,7 @@ public class AnsiConsole {
      * <code>AnsiConsole.err()</code> to <code>System.err</code>.
      * @see #systemUninstall()
      */
-    synchronized static public void systemInstall() {
+    public static synchronized void systemInstall() {
         if (installed == 0) {
             initStreams();
             try {
@@ -525,7 +520,7 @@ public class AnsiConsole {
     /**
      * check if the streams have been installed or not
      */
-    synchronized public static boolean isInstalled() {
+    public static synchronized boolean isInstalled() {
         return installed > 0;
     }
 
@@ -534,7 +529,7 @@ public class AnsiConsole {
      * multiple times, {@link #systemUninstall()} must be called the same number of times before
      * it is actually uninstalled.
      */
-    synchronized public static void systemUninstall() {
+    public static synchronized void systemUninstall() {
         installed--;
         if (installed == 0) {
             try {
@@ -552,14 +547,11 @@ public class AnsiConsole {
     /**
      * Initialize the out/err ansi-enabled streams
      */
-    synchronized static void initStreams()
-    {
-        if ( !initialized )
-        {
+    static synchronized void initStreams() {
+        if (!initialized) {
             out = ansiStream(true);
             err = ansiStream(false);
             initialized = true;
         }
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/AnsiMain.java
+++ b/src/main/java/org/fusesource/jansi/AnsiMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 package org.fusesource.jansi;
 
-import static org.fusesource.jansi.Ansi.ansi;
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -30,6 +28,8 @@ import java.util.Properties;
 import org.fusesource.jansi.Ansi.Attribute;
 import org.fusesource.jansi.internal.CLibrary;
 import org.fusesource.jansi.internal.JansiLoader;
+
+import static org.fusesource.jansi.Ansi.ansi;
 
 /**
  * Main class for the library, providing executable jar to diagnose Jansi setup.
@@ -82,12 +82,12 @@ public class AnsiMain {
         System.out.println();
 
         System.out.println("os.name= " + System.getProperty("os.name") + ", "
-                        + "os.version= " + System.getProperty("os.version") + ", "
-                        + "os.arch= " + System.getProperty("os.arch"));
+                + "os.version= " + System.getProperty("os.version") + ", "
+                + "os.arch= " + System.getProperty("os.arch"));
         System.out.println("file.encoding= " + System.getProperty("file.encoding"));
         System.out.println("java.version= " + System.getProperty("java.version") + ", "
-                        + "java.vendor= " + System.getProperty("java.vendor") + ","
-                        + " java.home= " + System.getProperty("java.home"));
+                + "java.vendor= " + System.getProperty("java.vendor") + ","
+                + " java.home= " + System.getProperty("java.home"));
 
         System.out.println();
 
@@ -98,7 +98,8 @@ public class AnsiMain {
         System.out.println(AnsiConsole.JANSI_COLORS + "= " + System.getProperty(AnsiConsole.JANSI_COLORS, ""));
         System.out.println(AnsiConsole.JANSI_OUT_COLORS + "= " + System.getProperty(AnsiConsole.JANSI_OUT_COLORS, ""));
         System.out.println(AnsiConsole.JANSI_ERR_COLORS + "= " + System.getProperty(AnsiConsole.JANSI_ERR_COLORS, ""));
-        System.out.println(AnsiConsole.JANSI_PASSTHROUGH + "= " + AnsiConsole.getBoolean(AnsiConsole.JANSI_PASSTHROUGH));
+        System.out.println(
+                AnsiConsole.JANSI_PASSTHROUGH + "= " + AnsiConsole.getBoolean(AnsiConsole.JANSI_PASSTHROUGH));
         System.out.println(AnsiConsole.JANSI_STRIP + "= " + AnsiConsole.getBoolean(AnsiConsole.JANSI_STRIP));
         System.out.println(AnsiConsole.JANSI_FORCE + "= " + AnsiConsole.getBoolean(AnsiConsole.JANSI_FORCE));
         System.out.println(AnsiConsole.JANSI_NORESET + "= " + AnsiConsole.getBoolean(AnsiConsole.JANSI_NORESET));
@@ -116,7 +117,7 @@ public class AnsiMain {
         System.out.println();
 
         diagnoseTty(false); // System.out
-        diagnoseTty(true);  // System.err
+        diagnoseTty(true); // System.err
 
         AnsiConsole.systemInstall();
 
@@ -153,10 +154,10 @@ public class AnsiMain {
 
             if (args.length == 1) {
                 File f = new File(args[0]);
-                if (f.exists())
-                {
+                if (f.exists()) {
                     // write file content
-                    System.out.println(ansi().bold().a("\"" + args[0] + "\" content:").reset());
+                    System.out.println(
+                            ansi().bold().a("\"" + args[0] + "\" content:").reset());
                     writeFileContent(f);
                     return;
                 }
@@ -165,14 +166,14 @@ public class AnsiMain {
             // write args without Jansi then with Jansi AnsiConsole
             System.out.println(ansi().bold().a("original args:").reset());
             int i = 1;
-            for (String arg: args) {
+            for (String arg : args) {
                 AnsiConsole.system_out.print(i++ + ": ");
                 AnsiConsole.system_out.println(arg);
             }
 
             System.out.println(ansi().bold().a("Jansi filtered args:").reset());
             i = 1;
-            for (String arg: args) {
+            for (String arg : args) {
                 System.out.print(i++ + ": ");
                 System.out.println(arg);
             }
@@ -183,7 +184,7 @@ public class AnsiMain {
 
     private static String getJansiVersion() {
         Package p = AnsiMain.class.getPackage();
-        return ( p == null ) ? null : p.getImplementationVersion();
+        return (p == null) ? null : p.getImplementationVersion();
     }
 
     private static void diagnoseTty(boolean stderr) {
@@ -191,40 +192,40 @@ public class AnsiMain {
         int isatty = CLibrary.LOADED ? CLibrary.isatty(fd) : 0;
 
         System.out.println("isatty(STD" + (stderr ? "ERR" : "OUT") + "_FILENO): " + isatty + ", System."
-            + (stderr ? "err" : "out") + " " + ((isatty == 0) ? "is *NOT*" : "is") + " a terminal");
+                + (stderr ? "err" : "out") + " " + ((isatty == 0) ? "is *NOT*" : "is") + " a terminal");
     }
 
     private static void testAnsi(boolean stderr) {
-        @SuppressWarnings( "resource" )
+        @SuppressWarnings("resource")
         PrintStream s = stderr ? System.err : System.out;
         s.print("test on System." + (stderr ? "err" : "out") + ":");
-        for(Ansi.Color c: Ansi.Color.values()) {
+        for (Ansi.Color c : Ansi.Color.values()) {
             s.print(" " + ansi().fg(c) + c + ansi().reset());
         }
         s.println();
         s.print("            bright:");
-        for(Ansi.Color c: Ansi.Color.values()) {
+        for (Ansi.Color c : Ansi.Color.values()) {
             s.print(" " + ansi().fgBright(c) + c + ansi().reset());
         }
         s.println();
         s.print("              bold:");
-        for(Ansi.Color c: Ansi.Color.values()) {
+        for (Ansi.Color c : Ansi.Color.values()) {
             s.print(" " + ansi().bold().fg(c) + c + ansi().reset());
         }
         s.println();
         s.print("             faint:");
-        for(Ansi.Color c: Ansi.Color.values()) {
+        for (Ansi.Color c : Ansi.Color.values()) {
             s.print(" " + ansi().a(Attribute.INTENSITY_FAINT).fg(c) + c + ansi().reset());
         }
         s.println();
         s.print("        bold+faint:");
-        for(Ansi.Color c: Ansi.Color.values()) {
+        for (Ansi.Color c : Ansi.Color.values()) {
             s.print(" " + ansi().bold().a(Attribute.INTENSITY_FAINT).fg(c) + c + ansi().reset());
         }
         s.println();
         Ansi ansi = ansi();
         ansi.a("        256 colors: ");
-        for (int i = 0; i < 6*6*6; i++) {
+        for (int i = 0; i < 6 * 6 * 6; i++) {
             if (i > 0 && i % 36 == 0) {
                 ansi.reset();
                 ansi.newline();
@@ -234,7 +235,7 @@ public class AnsiMain {
                 ansi.a("  ");
             }
             int a0 = i % 6;
-            int a1 = (i  / 6) % 6;
+            int a1 = (i / 6) % 6;
             int a2 = i / 36;
             ansi.bg(16 + a0 + a2 * 6 + a1 * 36).a(' ');
         }
@@ -272,7 +273,8 @@ public class AnsiMain {
     }
 
     private static void printJansiLogoDemo() throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(AnsiMain.class.getResourceAsStream("jansi.txt"), "UTF-8"));
+        BufferedReader in =
+                new BufferedReader(new InputStreamReader(AnsiMain.class.getResourceAsStream("jansi.txt"), "UTF-8"));
         try {
             String l;
             while ((l = in.readLine()) != null) {

--- a/src/main/java/org/fusesource/jansi/AnsiMode.java
+++ b/src/main/java/org/fusesource/jansi/AnsiMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package org.fusesource.jansi;
  * @since 2.1
  */
 public enum AnsiMode {
-
     Strip("Strip all ansi sequences"),
     Default("Print ansi sequences if the stream is a terminal"),
     Force("Always print ansi sequences, even if the stream is redirected");

--- a/src/main/java/org/fusesource/jansi/AnsiPrintStream.java
+++ b/src/main/java/org/fusesource/jansi/AnsiPrintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ public class AnsiPrintStream extends PrintStream {
         super(out, autoFlush);
     }
 
-    public AnsiPrintStream(AnsiOutputStream out, boolean autoFlush, String encoding) throws UnsupportedEncodingException {
+    public AnsiPrintStream(AnsiOutputStream out, boolean autoFlush, String encoding)
+            throws UnsupportedEncodingException {
         super(out, autoFlush, encoding);
     }
 

--- a/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,8 +115,7 @@ public class AnsiRenderer {
     }
 
     public static String render(final String text, final String... codes) {
-        return render(Ansi.ansi(), codes)
-                .a(text).reset().toString();
+        return render(Ansi.ansi(), codes).a(text).reset().toString();
     }
 
     /**
@@ -214,7 +213,7 @@ public class AnsiRenderer {
 
         // Aliases
         BOLD(Attribute.INTENSITY_BOLD),
-        FAINT(Attribute.INTENSITY_FAINT),;
+        FAINT(Attribute.INTENSITY_FAINT);
 
         private final Enum<?> n;
 
@@ -250,7 +249,5 @@ public class AnsiRenderer {
         }
     }
 
-    private AnsiRenderer() {
-    }
-
+    private AnsiRenderer() {}
 }

--- a/src/main/java/org/fusesource/jansi/AnsiRenderer.java
+++ b/src/main/java/org/fusesource/jansi/AnsiRenderer.java
@@ -99,6 +99,11 @@ public class AnsiRenderer {
                 return target;
             }
             j += BEGIN_TOKEN_LEN;
+
+            // Check for invalid string with END_TOKEN before BEGIN_TOKEN
+            if (k < j) {
+                throw new IllegalArgumentException("Invalid input string found.");
+            }
             String spec = input.substring(j, k);
 
             String[] items = spec.split(CODE_TEXT_SEPARATOR, 2);

--- a/src/main/java/org/fusesource/jansi/AnsiType.java
+++ b/src/main/java/org/fusesource/jansi/AnsiType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package org.fusesource.jansi;
  * @since 2.1
  */
 public enum AnsiType {
-
     Native("Supports ansi sequences natively"),
     Unsupported("Ansi sequences are stripped out"),
     VirtualTerminal("Supported through windows virtual terminal"),

--- a/src/main/java/org/fusesource/jansi/WindowsSupport.java
+++ b/src/main/java/org/fusesource/jansi/WindowsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2019 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,5 +38,4 @@ public class WindowsSupport {
             throw new IllegalStateException(e);
         }
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/internal/CLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/CLibrary.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -89,36 +89,20 @@ public class CLibrary {
      * @return 0 on success
      * @see <a href="http://man7.org/linux/man-pages/man3/openpty.3.html">OPENPTY(3) man-page</a>
      */
-    public static native int openpty(
-            int[] amaster,
-            int[] aslave,
-            byte[] name,
-            Termios termios,
-            WinSize winsize);
+    public static native int openpty(int[] amaster, int[] aslave, byte[] name, Termios termios, WinSize winsize);
 
-    public static native int tcgetattr(
-            int filedes,
-            Termios termios);
+    public static native int tcgetattr(int filedes, Termios termios);
 
-    public static native int tcsetattr(
-            int filedes,
-            int optional_actions,
-            Termios termios);
+    public static native int tcsetattr(int filedes, int optional_actions, Termios termios);
 
     /**
      * Control a STREAMS device.
      *
      * @see <a href="http://man7.org/linux/man-pages/man3/ioctl.3p.html">IOCTL(3P) man-page</a>
      */
-    public static native int ioctl(
-            int filedes,
-            long request,
-            int[] params);
+    public static native int ioctl(int filedes, long request, int[] params);
 
-    public static native int ioctl(
-            int filedes,
-            long request,
-            WinSize params);
+    public static native int ioctl(int filedes, long request, WinSize params);
 
     /**
      * Window sizes.
@@ -141,8 +125,7 @@ public class CLibrary {
         public short ws_xpixel;
         public short ws_ypixel;
 
-        public WinSize() {
-        }
+        public WinSize() {}
 
         public WinSize(short ws_row, short ws_col) {
             this.ws_row = ws_row;
@@ -175,5 +158,4 @@ public class CLibrary {
         public long c_ispeed;
         public long c_ospeed;
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/internal/CLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/CLibrary.java
@@ -20,7 +20,6 @@ package org.fusesource.jansi.internal;
  * <a href="http://fusesource.github.io/hawtjni/">HawtJNI</a> Runtime
  * as <code>jansi</code> library.
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @see JansiLoader
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
+++ b/src/main/java/org/fusesource/jansi/internal/JansiLoader.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.internal;
+
 /*--------------------------------------------------------------------------
  *  Copyright 2007 Taro L. Saito
  *
@@ -13,7 +30,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *--------------------------------------------------------------------------*/
-package org.fusesource.jansi.internal;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,7 +78,9 @@ public class JansiLoader {
             loadJansiNativeLibrary();
         } catch (Exception e) {
             if (!Boolean.parseBoolean(System.getProperty(AnsiConsole.JANSI_GRACEFUL, "true"))) {
-                throw new RuntimeException("Unable to load jansi native library. You may want set the `jansi.graceful` system property to true to be able to use Jansi on your platform", e);
+                throw new RuntimeException(
+                        "Unable to load jansi native library. You may want set the `jansi.graceful` system property to true to be able to use Jansi on your platform",
+                        e);
             }
         }
         return loaded;
@@ -114,8 +132,7 @@ public class JansiLoader {
         int len = b.length;
         while (n < len) {
             int count = in.read(b, n, len - n);
-            if (count <= 0)
-                break;
+            if (count <= 0) break;
             n += count;
         }
         return n;
@@ -160,8 +177,8 @@ public class JansiLoader {
      * @param targetFolder          Target folder.
      * @return
      */
-    private static boolean extractAndLoadLibraryFile(String libFolderForCurrentOS, String libraryFileName,
-                                                     String targetFolder) {
+    private static boolean extractAndLoadLibraryFile(
+            String libFolderForCurrentOS, String libraryFileName, String targetFolder) {
         String nativeLibraryFilePath = libFolderForCurrentOS + "/" + libraryFileName;
         // Include architecture name in temporary filename in order to avoid conflicts
         // when multiple JVMs with different architectures running at the same time
@@ -197,14 +214,16 @@ public class JansiLoader {
                 try (InputStream extractedLibIn = new FileInputStream(extractedLibFile)) {
                     String eq = contentsEquals(nativeIn, extractedLibIn);
                     if (eq != null) {
-                        throw new RuntimeException(String.format("Failed to write a native library file at %s because %s", extractedLibFile, eq));
+                        throw new RuntimeException(String.format(
+                                "Failed to write a native library file at %s because %s", extractedLibFile, eq));
                     }
                 }
             }
 
             // Load library
             if (loadNativeLibrary(extractedLibFile)) {
-                nativeLibrarySourceUrl = JansiLoader.class.getResource(nativeLibraryFilePath).toExternalForm();
+                nativeLibrarySourceUrl =
+                        JansiLoader.class.getResource(nativeLibraryFilePath).toExternalForm();
                 return true;
             }
         } catch (IOException e) {
@@ -241,13 +260,16 @@ public class JansiLoader {
             } catch (UnsatisfiedLinkError e) {
                 if (!libPath.canExecute()) {
                     // NOTE: this can be tested using something like:
-                    // docker run --rm --tmpfs /tmp -v $PWD:/jansi openjdk:11 java -jar /jansi/target/jansi-xxx-SNAPSHOT.jar
-                    System.err.printf("Failed to load native library:%s. The native library file at %s is not executable, "
-                            + "make sure that the directory is mounted on a partition without the noexec flag, or set the "
-                            + "jansi.tmpdir system property to point to a proper location.  osinfo: %s%n",
+                    // docker run --rm --tmpfs /tmp -v $PWD:/jansi openjdk:11 java -jar
+                    // /jansi/target/jansi-xxx-SNAPSHOT.jar
+                    System.err.printf(
+                            "Failed to load native library:%s. The native library file at %s is not executable, "
+                                    + "make sure that the directory is mounted on a partition without the noexec flag, or set the "
+                                    + "jansi.tmpdir system property to point to a proper location.  osinfo: %s%n",
                             libPath.getName(), libPath, OSInfo.getNativeLibFolderPathForCurrentOS());
                 } else {
-                    System.err.printf("Failed to load native library:%s. osinfo: %s%n",
+                    System.err.printf(
+                            "Failed to load native library:%s. osinfo: %s%n",
                             libPath.getName(), OSInfo.getNativeLibFolderPathForCurrentOS());
                 }
                 System.err.println(e);
@@ -301,9 +323,9 @@ public class JansiLoader {
 
         // Load the os-dependent library from the jar file
         String packagePath = JansiLoader.class.getPackage().getName().replace('.', '/');
-        jansiNativeLibraryPath = String.format("/%s/native/%s", packagePath, OSInfo.getNativeLibFolderPathForCurrentOS());
+        jansiNativeLibraryPath =
+                String.format("/%s/native/%s", packagePath, OSInfo.getNativeLibFolderPathForCurrentOS());
         boolean hasNativeLib = hasResource(jansiNativeLibraryPath + "/" + jansiNativeLibraryName);
-
 
         if (hasNativeLib) {
             // temporary library folder
@@ -331,14 +353,14 @@ public class JansiLoader {
             }
         }
 
-        throw new Exception(String.format("No native library found for os.name=%s, os.arch=%s, paths=[%s]",
+        throw new Exception(String.format(
+                "No native library found for os.name=%s, os.arch=%s, paths=[%s]",
                 OSInfo.getOSName(), OSInfo.getArchName(), join(triedPaths, File.pathSeparator)));
     }
 
     private static boolean hasResource(String path) {
         return JansiLoader.class.getResource(path) != null;
     }
-
 
     /**
      * @return The major version of the jansi library.
@@ -381,14 +403,11 @@ public class JansiLoader {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
         for (String item : list) {
-            if (first)
-                first = false;
-            else
-                sb.append(separator);
+            if (first) first = false;
+            else sb.append(separator);
 
             sb.append(item);
         }
         return sb.toString();
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/internal/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/internal/Kernel32.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,7 +58,6 @@ public class Kernel32 {
     public static int STD_ERROR_HANDLE;
     public static int INVALID_HANDLE_VALUE;
 
-
     public static native long malloc(long size);
 
     public static native void free(long ptr);
@@ -66,7 +65,7 @@ public class Kernel32 {
     /**
      * http://msdn.microsoft.com/en-us/library/ms686311%28VS.85%29.aspx
      */
-    static public class SMALL_RECT {
+    public static class SMALL_RECT {
         static {
             JansiLoader.initialize();
             init();
@@ -102,9 +101,7 @@ public class Kernel32 {
     /**
      * see http://msdn.microsoft.com/en-us/library/ms686047%28VS.85%29.aspx
      */
-    public static native int SetConsoleTextAttribute(
-            long consoleOutput,
-            short attributes);
+    public static native int SetConsoleTextAttribute(long consoleOutput, short attributes);
 
     public static class COORD {
 
@@ -157,7 +154,6 @@ public class Kernel32 {
         }
     }
 
-
     // DWORD WINAPI WaitForSingleObject(
     //  _In_ HANDLE hHandle,
     //  _In_ DWORD  dwMilliseconds
@@ -169,29 +165,19 @@ public class Kernel32 {
      */
     public static native int CloseHandle(long handle);
 
-
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms679360(VS.85).aspx
      */
     public static native int GetLastError();
 
     public static native int FormatMessageW(
-            int flags,
-            long source,
-            int messageId,
-            int languageId,
-            byte[] buffer,
-            int size,
-            long[] args
-    );
-
+            int flags, long source, int messageId, int languageId, byte[] buffer, int size, long[] args);
 
     /**
      * See: http://msdn.microsoft.com/en-us/library/ms683171%28VS.85%29.aspx
      */
     public static native int GetConsoleScreenBufferInfo(
-            long consoleOutput,
-            CONSOLE_SCREEN_BUFFER_INFO consoleScreenBufferInfo);
+            long consoleOutput, CONSOLE_SCREEN_BUFFER_INFO consoleScreenBufferInfo);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms683231%28VS.85%29.aspx
@@ -201,68 +187,47 @@ public class Kernel32 {
     /**
      * http://msdn.microsoft.com/en-us/library/ms686025%28VS.85%29.aspx
      */
-    public static native int SetConsoleCursorPosition(
-            long consoleOutput,
-            COORD cursorPosition);
+    public static native int SetConsoleCursorPosition(long consoleOutput, COORD cursorPosition);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms682663%28VS.85%29.aspx
      */
     public static native int FillConsoleOutputCharacterW(
-            long consoleOutput,
-            char character,
-            int length,
-            COORD writeCoord,
-            int[] numberOfCharsWritten);
+            long consoleOutput, char character, int length, COORD writeCoord, int[] numberOfCharsWritten);
 
     /**
      * see: https://msdn.microsoft.com/en-us/library/ms682662%28VS.85%29.aspx
      */
     public static native int FillConsoleOutputAttribute(
-            long consoleOutput,
-            short attribute,
-            int length,
-            COORD writeCoord,
-            int[] numberOfAttrsWritten);
+            long consoleOutput, short attribute, int length, COORD writeCoord, int[] numberOfAttrsWritten);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms687401(v=VS.85).aspx
      */
     public static native int WriteConsoleW(
-            long consoleOutput,
-            char[] buffer,
-            int numberOfCharsToWrite,
-            int[] numberOfCharsWritten,
-            long reserved);
+            long consoleOutput, char[] buffer, int numberOfCharsToWrite, int[] numberOfCharsWritten, long reserved);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms683167%28VS.85%29.aspx
      */
-    public static native int GetConsoleMode(
-            long handle,
-            int[] mode);
+    public static native int GetConsoleMode(long handle, int[] mode);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms686033%28VS.85%29.aspx
      */
-    public static native int SetConsoleMode(
-            long handle,
-            int mode);
+    public static native int SetConsoleMode(long handle, int mode);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/078sfkak(VS.80).aspx
      */
     public static native int _getch();
 
-
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms686050%28VS.85%29.aspx
      *
      * @return 0 if title was set successfully
      */
-    public static native int SetConsoleTitle(
-            String title);
-
+    public static native int SetConsoleTitle(String title);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms683169(v=VS.85).aspx
@@ -337,14 +302,13 @@ public class Kernel32 {
         public int controlKeyState;
 
         public String toString() {
-            return "KEY_EVENT_RECORD{" +
-                    "keyDown=" + keyDown +
-                    ", repeatCount=" + repeatCount +
-                    ", keyCode=" + keyCode +
-                    ", scanCode=" + scanCode +
-                    ", uchar=" + uchar +
-                    ", controlKeyState=" + controlKeyState +
-                    '}';
+            return "KEY_EVENT_RECORD{" + "keyDown="
+                    + keyDown + ", repeatCount="
+                    + repeatCount + ", keyCode="
+                    + keyCode + ", scanCode="
+                    + scanCode + ", uchar="
+                    + uchar + ", controlKeyState="
+                    + controlKeyState + '}';
         }
     }
 
@@ -388,12 +352,11 @@ public class Kernel32 {
         public int eventFlags;
 
         public String toString() {
-            return "MOUSE_EVENT_RECORD{" +
-                    "mousePosition=" + mousePosition +
-                    ", buttonState=" + buttonState +
-                    ", controlKeyState=" + controlKeyState +
-                    ", eventFlags=" + eventFlags +
-                    '}';
+            return "MOUSE_EVENT_RECORD{" + "mousePosition="
+                    + mousePosition + ", buttonState="
+                    + buttonState + ", controlKeyState="
+                    + controlKeyState + ", eventFlags="
+                    + eventFlags + '}';
         }
     }
 
@@ -473,49 +436,33 @@ public class Kernel32 {
         public MENU_EVENT_RECORD menuEvent = new MENU_EVENT_RECORD();
         public FOCUS_EVENT_RECORD focusEvent = new FOCUS_EVENT_RECORD();
 
-        public static native void memmove(
-                INPUT_RECORD dest,
-                long src,
-                long size);
-
+        public static native void memmove(INPUT_RECORD dest, long src, long size);
     }
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms684961(v=VS.85).aspx
      */
-    private static native int ReadConsoleInputW(
-            long handle,
-            long inputRecord,
-            int length,
-            int[] eventsCount);
+    private static native int ReadConsoleInputW(long handle, long inputRecord, int length, int[] eventsCount);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms684344(v=VS.85).aspx
      */
-    private static native int PeekConsoleInputW(
-            long handle,
-            long inputRecord,
-            int length,
-            int[] eventsCount);
+    private static native int PeekConsoleInputW(long handle, long inputRecord, int length, int[] eventsCount);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms683207(v=VS.85).aspx
      */
-    public static native int GetNumberOfConsoleInputEvents(
-            long handle,
-            int[] numberOfEvents);
+    public static native int GetNumberOfConsoleInputEvents(long handle, int[] numberOfEvents);
 
     /**
      * see: http://msdn.microsoft.com/en-us/library/ms683147(v=VS.85).aspx
      */
-    public static native int FlushConsoleInputBuffer(
-            long handle);
+    public static native int FlushConsoleInputBuffer(long handle);
 
     /**
      * Return console input events.
      */
-    public static INPUT_RECORD[] readConsoleInputHelper(
-            long handle, int count, boolean peek) throws IOException {
+    public static INPUT_RECORD[] readConsoleInputHelper(long handle, int count, boolean peek) throws IOException {
         int[] length = new int[1];
         int res;
         long inputRecordPtr = 0;
@@ -524,8 +471,8 @@ public class Kernel32 {
             if (inputRecordPtr == 0) {
                 throw new IOException("cannot allocate memory with JNI");
             }
-            res = peek ?
-                    PeekConsoleInputW(handle, inputRecordPtr, count, length)
+            res = peek
+                    ? PeekConsoleInputW(handle, inputRecordPtr, count, length)
                     : ReadConsoleInputW(handle, inputRecordPtr, count, length);
             if (res == 0) {
                 throw new IOException("ReadConsoleInputW failed: " + WindowsSupport.getLastErrorMessage());
@@ -552,8 +499,7 @@ public class Kernel32 {
      * @param count requested number of events
      * @return array possibly of size smaller then count
      */
-    public static INPUT_RECORD[] readConsoleKeyInput(long handle, int count, boolean peek)
-            throws IOException {
+    public static INPUT_RECORD[] readConsoleKeyInput(long handle, int count, boolean peek) throws IOException {
         while (true) {
             // read events until we have keyboard events, the queue could be full
             // of mouse events.
@@ -574,6 +520,4 @@ public class Kernel32 {
             }
         }
     }
-
-
 }

--- a/src/main/java/org/fusesource/jansi/internal/Kernel32.java
+++ b/src/main/java/org/fusesource/jansi/internal/Kernel32.java
@@ -22,8 +22,6 @@ import org.fusesource.jansi.WindowsSupport;
 /**
  * Interface to access Win32 base APIs.
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- * @author Guillaume Nodet
  * @see JansiLoader
  */
 @SuppressWarnings("unused")

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2009-2023 the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.jansi.internal;
+
 /*--------------------------------------------------------------------------
  *  Copyright 2008 Taro L. Saito
  *
@@ -13,7 +30,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *--------------------------------------------------------------------------*/
-package org.fusesource.jansi.internal;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,6 +53,7 @@ public class OSInfo {
     public static final String ARM64 = "arm64";
 
     private static final HashMap<String, String> archMapping = new HashMap<String, String>();
+
     static {
         // x86 mappings
         archMapping.put(X86, X86);
@@ -77,7 +94,6 @@ public class OSInfo {
         // aarch64 mappings
         archMapping.put("aarch64", ARM64);
     }
-
 
     public static void main(String[] args) {
         if (args.length >= 1) {
@@ -120,7 +136,6 @@ public class OSInfo {
         } catch (Throwable e) {
             return false;
         }
-
     }
 
     static String getHardwareName() {
@@ -190,8 +205,7 @@ public class OSInfo {
             osArch = resolveArmArchType();
         } else {
             String lc = osArch.toLowerCase(Locale.US);
-            if (archMapping.containsKey(lc))
-                return archMapping.get(lc);
+            if (archMapping.containsKey(lc)) return archMapping.get(lc);
         }
         return translateArchNameToFolderName(osArch);
     }
@@ -201,8 +215,8 @@ public class OSInfo {
             return "Windows";
         } else if (osName.contains("Mac") || osName.contains("Darwin")) {
             return "Mac";
-//        } else if (isAlpine()) {
-//            return "Linux-Alpine";
+            //        } else if (isAlpine()) {
+            //            return "Linux-Alpine";
         } else if (osName.contains("Linux")) {
             return "Linux";
         } else if (osName.contains("AIX")) {

--- a/src/main/java/org/fusesource/jansi/internal/OSInfo.java
+++ b/src/main/java/org/fusesource/jansi/internal/OSInfo.java
@@ -40,7 +40,6 @@ import java.util.Locale;
 /**
  * Provides OS name and architecture name.
  *
- * @author leo
  */
 public class OSInfo {
 

--- a/src/main/java/org/fusesource/jansi/io/AnsiOutputStream.java
+++ b/src/main/java/org/fusesource/jansi/io/AnsiOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.fusesource.jansi.AnsiMode;
 import org.fusesource.jansi.AnsiType;
 
 /**
- * A ANSI print stream extracts ANSI escape codes written to 
+ * A ANSI print stream extracts ANSI escape codes written to
  * an output stream and calls corresponding <code>AnsiProcessor.process*</code> methods.
  * This particular class is not synchronized for improved performances.
  *
@@ -76,7 +76,7 @@ public class AnsiOutputStream extends FilterOutputStream {
     private static final int SECOND_CHARSET1_CHAR = ')';
 
     private AnsiProcessor ap;
-    private final static int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
+    private static final int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
     private final byte[] buffer = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
     private int pos = 0;
     private int startOfValue;
@@ -93,9 +93,17 @@ public class AnsiOutputStream extends FilterOutputStream {
     private AnsiMode mode;
     private boolean resetAtUninstall;
 
-    public AnsiOutputStream(OutputStream os, WidthSupplier width, AnsiMode mode,
-                            AnsiProcessor processor, AnsiType type, AnsiColors colors,
-                            Charset cs, IoRunnable installer, IoRunnable uninstaller, boolean resetAtUninstall) {
+    public AnsiOutputStream(
+            OutputStream os,
+            WidthSupplier width,
+            AnsiMode mode,
+            AnsiProcessor processor,
+            AnsiType type,
+            AnsiColors colors,
+            Charset cs,
+            IoRunnable installer,
+            IoRunnable uninstaller,
+            boolean resetAtUninstall) {
         super(os);
         this.width = width;
         this.processor = processor;
@@ -330,9 +338,7 @@ public class AnsiOutputStream extends FilterOutputStream {
     }
 
     public void uninstall() throws IOException {
-        if (resetAtUninstall
-                && type != AnsiType.Redirected
-                && type != AnsiType.Unsupported) {
+        if (resetAtUninstall && type != AnsiType.Redirected && type != AnsiType.Unsupported) {
             setMode(AnsiMode.Default);
             write(RESET_CODE);
             flush();

--- a/src/main/java/org/fusesource/jansi/io/AnsiOutputStream.java
+++ b/src/main/java/org/fusesource/jansi/io/AnsiOutputStream.java
@@ -33,7 +33,6 @@ import org.fusesource.jansi.AnsiType;
  * <p>For more information about ANSI escape codes, see
  * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code">Wikipedia article</a>
  *
- * @author Guillaume Nodet
  * @since 1.0
  * @see AnsiProcessor
  */

--- a/src/main/java/org/fusesource/jansi/io/AnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/io/AnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
- * ANSI processor providing <code>process*</code> corresponding to ANSI escape codes. 
+ * ANSI processor providing <code>process*</code> corresponding to ANSI escape codes.
  * This class methods implementations are empty: subclasses should actually perform the
  * ANSI escape behaviors by implementing active code in <code>process*</code> methods.
- * 
+ *
  * <p>For more information about ANSI escape codes, see
  * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code">Wikipedia article</a>
  *
@@ -44,12 +44,10 @@ public class AnsiProcessor {
      * @throws IOException      if no more non-null values left
      */
     protected int getNextOptionInt(Iterator<Object> optionsIterator) throws IOException {
-        for (;;) {
-            if (!optionsIterator.hasNext())
-                throw new IllegalArgumentException();
+        for (; ; ) {
+            if (!optionsIterator.hasNext()) throw new IllegalArgumentException();
             Object arg = optionsIterator.next();
-            if (arg != null)
-                return (Integer) arg;
+            if (arg != null) return (Integer) arg;
         }
     }
 
@@ -137,27 +135,21 @@ public class AnsiProcessor {
                                     int g = getNextOptionInt(optionsIterator);
                                     int b = getNextOptionInt(optionsIterator);
                                     if (r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
-                                        if (value == 38)
-                                            processSetForegroundColorExt(r, g, b);
-                                        else
-                                            processSetBackgroundColorExt(r, g, b);
+                                        if (value == 38) processSetForegroundColorExt(r, g, b);
+                                        else processSetBackgroundColorExt(r, g, b);
                                     } else {
                                         throw new IllegalArgumentException();
                                     }
-                                }
-                                else if (arg2or5 == 5) {
+                                } else if (arg2or5 == 5) {
                                     // 256 color style like `esc[38;5;<index>m`
                                     int paletteIndex = getNextOptionInt(optionsIterator);
                                     if (paletteIndex >= 0 && paletteIndex <= 255) {
-                                        if (value == 38)
-                                            processSetForegroundColorExt(paletteIndex);
-                                        else
-                                            processSetBackgroundColorExt(paletteIndex);
+                                        if (value == 38) processSetForegroundColorExt(paletteIndex);
+                                        else processSetBackgroundColorExt(paletteIndex);
                                     } else {
                                         throw new IllegalArgumentException();
                                     }
-                                }
-                                else {
+                                } else {
                                     throw new IllegalArgumentException();
                                 }
                             } else {
@@ -247,13 +239,10 @@ public class AnsiProcessor {
     }
 
     private int optionInt(ArrayList<Object> options, int index) {
-        if (options.size() <= index)
-            throw new IllegalArgumentException();
+        if (options.size() <= index) throw new IllegalArgumentException();
         Object value = options.get(index);
-        if (value == null)
-            throw new IllegalArgumentException();
-        if (!value.getClass().equals(Integer.class))
-            throw new IllegalArgumentException();
+        if (value == null) throw new IllegalArgumentException();
+        if (!value.getClass().equals(Integer.class)) throw new IllegalArgumentException();
         return (Integer) value;
     }
 
@@ -272,15 +261,13 @@ public class AnsiProcessor {
      * Process <code>CSI u</code> ANSI code, corresponding to <code>RCP – Restore Cursor Position</code>
      * @throws IOException IOException
      */
-    protected void processRestoreCursorPosition() throws IOException {
-    }
+    protected void processRestoreCursorPosition() throws IOException {}
 
     /**
      * Process <code>CSI s</code> ANSI code, corresponding to <code>SCP – Save Cursor Position</code>
      * @throws IOException IOException
      */
-    protected void processSaveCursorPosition() throws IOException {
-    }
+    protected void processSaveCursorPosition() throws IOException {}
 
     /**
      * Process <code>CSI L</code> ANSI code, corresponding to <code>IL – Insert Line</code>
@@ -288,8 +275,7 @@ public class AnsiProcessor {
      * @throws IOException IOException
      * @since 1.16
      */
-    protected void processInsertLine(int optionInt) throws IOException {
-    }
+    protected void processInsertLine(int optionInt) throws IOException {}
 
     /**
      * Process <code>CSI M</code> ANSI code, corresponding to <code>DL – Delete Line</code>
@@ -297,24 +283,21 @@ public class AnsiProcessor {
      * @throws IOException IOException
      * @since 1.16
      */
-    protected void processDeleteLine(int optionInt) throws IOException {
-    }
+    protected void processDeleteLine(int optionInt) throws IOException {}
 
     /**
      * Process <code>CSI n T</code> ANSI code, corresponding to <code>SD – Scroll Down</code>
      * @param optionInt option
      * @throws IOException IOException
      */
-    protected void processScrollDown(int optionInt) throws IOException {
-    }
+    protected void processScrollDown(int optionInt) throws IOException {}
 
     /**
      * Process <code>CSI n U</code> ANSI code, corresponding to <code>SU – Scroll Up</code>
      * @param optionInt option
      * @throws IOException IOException
      */
-    protected void processScrollUp(int optionInt) throws IOException {
-    }
+    protected void processScrollUp(int optionInt) throws IOException {}
 
     protected static final int ERASE_SCREEN_TO_END = 0;
     protected static final int ERASE_SCREEN_TO_BEGINING = 1;
@@ -325,8 +308,7 @@ public class AnsiProcessor {
      * @param eraseOption eraseOption
      * @throws IOException IOException
      */
-    protected void processEraseScreen(int eraseOption) throws IOException {
-    }
+    protected void processEraseScreen(int eraseOption) throws IOException {}
 
     protected static final int ERASE_LINE_TO_END = 0;
     protected static final int ERASE_LINE_TO_BEGINING = 1;
@@ -337,8 +319,7 @@ public class AnsiProcessor {
      * @param eraseOption eraseOption
      * @throws IOException IOException
      */
-    protected void processEraseLine(int eraseOption) throws IOException {
-    }
+    protected void processEraseLine(int eraseOption) throws IOException {}
 
     protected static final int ATTRIBUTE_INTENSITY_BOLD = 1; // 	Intensity: Bold
     protected static final int ATTRIBUTE_INTENSITY_FAINT = 2; // 	Intensity; Faint 	not widely supported
@@ -346,7 +327,8 @@ public class AnsiProcessor {
     protected static final int ATTRIBUTE_UNDERLINE = 4; // 	Underline; Single
     protected static final int ATTRIBUTE_BLINK_SLOW = 5; // 	Blink; Slow 	less than 150 per minute
     protected static final int ATTRIBUTE_BLINK_FAST = 6; // 	Blink; Rapid 	MS-DOS ANSI.SYS; 150 per minute or more
-    protected static final int ATTRIBUTE_NEGATIVE_ON = 7; // 	Image; Negative 	inverse or reverse; swap foreground and background
+    protected static final int ATTRIBUTE_NEGATIVE_ON =
+            7; // 	Image; Negative 	inverse or reverse; swap foreground and background
     protected static final int ATTRIBUTE_CONCEAL_ON = 8; // 	Conceal on
     protected static final int ATTRIBUTE_UNDERLINE_DOUBLE = 21; // 	Underline; Double 	not widely supported
     protected static final int ATTRIBUTE_INTENSITY_NORMAL = 22; // 	Intensity; Normal 	not bold and not faint
@@ -369,8 +351,7 @@ public class AnsiProcessor {
      * @see #processDefaultTextColor()
      * @see #processDefaultBackgroundColor()
      */
-    protected void processSetAttribute(int attribute) throws IOException {
-    }
+    protected void processSetAttribute(int attribute) throws IOException {}
 
     protected static final int BLACK = 0;
     protected static final int RED = 1;
@@ -397,8 +378,7 @@ public class AnsiProcessor {
      * @param bright is high intensity?
      * @throws IOException IOException
      */
-    protected void processSetForegroundColor(int color, boolean bright) throws IOException {
-    }
+    protected void processSetForegroundColor(int color, boolean bright) throws IOException {}
 
     /**
      * process <code>SGR 38</code> corresponding to <code>extended set text color (foreground)</code>
@@ -406,8 +386,7 @@ public class AnsiProcessor {
      * @param paletteIndex the text color in the palette
      * @throws IOException IOException
      */
-    protected void processSetForegroundColorExt(int paletteIndex) throws IOException {
-    }
+    protected void processSetForegroundColorExt(int paletteIndex) throws IOException {}
 
     /**
      * process <code>SGR 38</code> corresponding to <code>extended set text color (foreground)</code>
@@ -417,8 +396,7 @@ public class AnsiProcessor {
      * @param b blue
      * @throws IOException IOException
      */
-    protected void processSetForegroundColorExt(int r, int g, int b) throws IOException {
-    }
+    protected void processSetForegroundColorExt(int r, int g, int b) throws IOException {}
 
     /**
      * process <code>SGR 40-47</code> corresponding to <code>Set background color</code>.
@@ -436,8 +414,7 @@ public class AnsiProcessor {
      * @param bright is high intensity?
      * @throws IOException IOException
      */
-    protected void processSetBackgroundColor(int color, boolean bright) throws IOException {
-    }
+    protected void processSetBackgroundColor(int color, boolean bright) throws IOException {}
 
     /**
      * process <code>SGR 48</code> corresponding to <code>extended set background color</code>
@@ -445,8 +422,7 @@ public class AnsiProcessor {
      * @param paletteIndex the background color in the palette
      * @throws IOException IOException
      */
-    protected void processSetBackgroundColorExt(int paletteIndex) throws IOException {
-    }
+    protected void processSetBackgroundColorExt(int paletteIndex) throws IOException {}
 
     /**
      * process <code>SGR 48</code> corresponding to <code>extended set background color</code>
@@ -456,29 +432,25 @@ public class AnsiProcessor {
      * @param b blue
      * @throws IOException IOException
      */
-    protected void processSetBackgroundColorExt(int r, int g, int b) throws IOException {
-    }
+    protected void processSetBackgroundColorExt(int r, int g, int b) throws IOException {}
 
     /**
      * process <code>SGR 39</code> corresponding to <code>Default text color (foreground)</code>
      * @throws IOException IOException
      */
-    protected void processDefaultTextColor() throws IOException {
-    }
+    protected void processDefaultTextColor() throws IOException {}
 
     /**
      * process <code>SGR 49</code> corresponding to <code>Default background color</code>
      * @throws IOException IOException
      */
-    protected void processDefaultBackgroundColor() throws IOException {
-    }
+    protected void processDefaultBackgroundColor() throws IOException {}
 
     /**
      * process <code>SGR 0</code> corresponding to <code>Reset / Normal</code>
      * @throws IOException IOException
      */
-    protected void processAttributeReset() throws IOException {
-    }
+    protected void processAttributeReset() throws IOException {}
 
     /**
      * process <code>CSI n ; m H</code> corresponding to <code>CUP – Cursor Position</code> or
@@ -487,24 +459,21 @@ public class AnsiProcessor {
      * @param col col
      * @throws IOException IOException
      */
-    protected void processCursorTo(int row, int col) throws IOException {
-    }
+    protected void processCursorTo(int row, int col) throws IOException {}
 
     /**
      * process <code>CSI n G</code> corresponding to <code>CHA – Cursor Horizontal Absolute</code>
      * @param x the column
      * @throws IOException IOException
      */
-    protected void processCursorToColumn(int x) throws IOException {
-    }
+    protected void processCursorToColumn(int x) throws IOException {}
 
     /**
      * process <code>CSI n F</code> corresponding to <code>CPL – Cursor Previous Line</code>
      * @param count line count
      * @throws IOException IOException
      */
-    protected void processCursorUpLine(int count) throws IOException {
-    }
+    protected void processCursorUpLine(int count) throws IOException {}
 
     /**
      * process <code>CSI n E</code> corresponding to <code>CNL – Cursor Next Line</code>
@@ -523,8 +492,7 @@ public class AnsiProcessor {
      * @param count count
      * @throws IOException IOException
      */
-    protected void processCursorLeft(int count) throws IOException {
-    }
+    protected void processCursorLeft(int count) throws IOException {}
 
     /**
      * process <code>CSI n C</code> corresponding to <code>CUF – Cursor Forward</code>
@@ -543,24 +511,21 @@ public class AnsiProcessor {
      * @param count count
      * @throws IOException IOException
      */
-    protected void processCursorDown(int count) throws IOException {
-    }
+    protected void processCursorDown(int count) throws IOException {}
 
     /**
      * process <code>CSI n A</code> corresponding to <code>CUU – Cursor Up</code>
      * @param count count
      * @throws IOException IOException
      */
-    protected void processCursorUp(int count) throws IOException {
-    }
+    protected void processCursorUp(int count) throws IOException {}
 
     /**
      * Process Unknown Extension
      * @param options options
      * @param command command
      */
-    protected void processUnknownExtension(ArrayList<Object> options, int command) {
-    }
+    protected void processUnknownExtension(ArrayList<Object> options, int command) {}
 
     /**
      * process <code>OSC 0;text BEL</code> corresponding to <code>Change Window and Icon label</code>
@@ -575,24 +540,20 @@ public class AnsiProcessor {
      * process <code>OSC 1;text BEL</code> corresponding to <code>Change Icon label</code>
      * @param label icon label
      */
-    protected void processChangeIconName(String label) {
-    }
+    protected void processChangeIconName(String label) {}
 
     /**
      * process <code>OSC 2;text BEL</code> corresponding to <code>Change Window title</code>
      * @param label window title text
      */
-    protected void processChangeWindowTitle(String label) {
-    }
+    protected void processChangeWindowTitle(String label) {}
 
     /**
      * Process unknown <code>OSC</code> command.
      * @param command command
      * @param param param
      */
-    protected void processUnknownOperatingSystemCommand(int command, String param) {
-    }
+    protected void processUnknownOperatingSystemCommand(int command, String param) {}
 
-    protected void processCharsetSelect(int set, char seq) {
-    }
+    protected void processCharsetSelect(int set, char seq) {}
 }

--- a/src/main/java/org/fusesource/jansi/io/Colors.java
+++ b/src/main/java/org/fusesource/jansi/io/Colors.java
@@ -1,10 +1,17 @@
 /*
- * Copyright (c) 2002-2018, the original author or authors.
+ * Copyright (C) 2009-2023 the original author(s).
  *
- * This software is distributable under the BSD license. See the terms of the
- * BSD license in the documentation provided with this software.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://opensource.org/licenses/BSD-3-Clause
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.fusesource.jansi.io;
 
@@ -18,6 +25,7 @@ public class Colors {
     /**
      * Default 256 colors palette
      */
+    // spotless:off
     public static final int[] DEFAULT_COLORS_256 = {
             // 16 ansi
             0x000000, 0x800000, 0x008000, 0x808000, 0x000080, 0x800080, 0x008080, 0xc0c0c0,
@@ -71,6 +79,7 @@ public class Colors {
             0x585858, 0x626262, 0x6c6c6c, 0x767676, 0x808080, 0x8a8a8a, 0x949494, 0x9e9e9e,
             0xa8a8a8, 0xb2b2b2, 0xbcbcbc, 0xc6c6c6, 0xd0d0d0, 0xdadada, 0xe4e4e4, 0xeeeeee,
     };
+    // spotless:on
 
     public static int roundColor(int col, int max) {
         if (col >= max) {
@@ -102,16 +111,14 @@ public class Colors {
     }
 
     private static double scalar(double[] c1, double[] c2) {
-        return sqr(c1[0] - c2[0])
-             + sqr(c1[1] - c2[1])
-             + sqr(c1[2] - c2[2]);
+        return sqr(c1[0] - c2[0]) + sqr(c1[1] - c2[1]) + sqr(c1[2] - c2[2]);
     }
 
     private static double[] rgb(int color) {
         int r = (color >> 16) & 0xFF;
-        int g = (color >>  8) & 0xFF;
-        int b = (color >>  0) & 0xFF;
-        return new double[] { r / 255.0, g / 255.0, b / 255.0 };
+        int g = (color >> 8) & 0xFF;
+        int b = (color >> 0) & 0xFF;
+        return new double[] {r / 255.0, g / 255.0, b / 255.0};
     }
 
     private static double[] rgb2cielab(int color) {
@@ -130,7 +137,7 @@ public class Colors {
         double x = vr * 0.4124564 + vg * 0.3575761 + vb * 0.1804375;
         double y = vr * 0.2126729 + vg * 0.7151522 + vb * 0.0721750;
         double z = vr * 0.0193339 + vg * 0.1191920 + vb * 0.9503041;
-        return new double[] { x, y, z };
+        return new double[] {x, y, z};
     }
 
     private static double pivotRgb(double n) {
@@ -144,11 +151,12 @@ public class Colors {
         double l = 116.0 * fy - 16.0;
         double a = 500.0 * (fx - fy);
         double b = 200.0 * (fy - fz);
-        return new double[] { l, a, b };
+        return new double[] {l, a, b};
     }
 
     private static final double epsilon = 216.0 / 24389.0;
     private static final double kappa = 24389.0 / 27.0;
+
     private static double pivotXyz(double n) {
         return n > epsilon ? Math.cbrt(n) : (kappa * n + 16) / 116;
     }
@@ -156,5 +164,4 @@ public class Colors {
     private static double sqr(double n) {
         return n * n;
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/io/ColorsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/io/ColorsAnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,12 @@ public class ColorsAnsiProcessor extends AnsiProcessor {
                                     sb.append(';');
                                 }
                                 first = false;
-                                sb.append(value == 38 ? col >= 8 ? 90 + col - 8 : 30 + col : col >= 8 ? 100 + col - 8 : 40 + col);
+                                sb.append(
+                                        value == 38
+                                                ? col >= 8 ? 90 + col - 8 : 30 + col
+                                                : col >= 8 ? 100 + col - 8 : 40 + col);
                             }
-                        }
-                        else if (arg2or5 == 5) {
+                        } else if (arg2or5 == 5) {
                             // 256 color style like `esc[38;5;<index>m`
                             int paletteIndex = getNextOptionInt(optionsIterator);
                             if (colors == AnsiColors.Colors256) {
@@ -105,10 +107,12 @@ public class ColorsAnsiProcessor extends AnsiProcessor {
                                     sb.append(';');
                                 }
                                 first = false;
-                                sb.append(value == 38 ? col >= 8 ? 90 + col - 8 : 30 + col : col >= 8 ? 100 + col - 8 : 40 + col);
+                                sb.append(
+                                        value == 38
+                                                ? col >= 8 ? 90 + col - 8 : 30 + col
+                                                : col >= 8 ? 100 + col - 8 : 40 + col);
                             }
-                        }
-                        else {
+                        } else {
                             throw new IllegalArgumentException();
                         }
                     } else {
@@ -138,5 +142,4 @@ public class ColorsAnsiProcessor extends AnsiProcessor {
     protected boolean processCharsetSelect(ArrayList<Object> options) {
         return false;
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/io/FastBufferedOutputStream.java
+++ b/src/main/java/org/fusesource/jansi/io/FastBufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,5 +65,4 @@ public class FastBufferedOutputStream extends FilterOutputStream {
         flushBuffer();
         out.flush();
     }
-
 }

--- a/src/main/java/org/fusesource/jansi/io/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/io/WindowsAnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,13 @@
  */
 package org.fusesource.jansi.io;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.fusesource.jansi.WindowsSupport;
+import org.fusesource.jansi.internal.Kernel32.CONSOLE_SCREEN_BUFFER_INFO;
+import org.fusesource.jansi.internal.Kernel32.COORD;
+
 import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_BLUE;
 import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_GREEN;
 import static org.fusesource.jansi.internal.Kernel32.BACKGROUND_INTENSITY;
@@ -29,23 +36,16 @@ import static org.fusesource.jansi.internal.Kernel32.FillConsoleOutputCharacterW
 import static org.fusesource.jansi.internal.Kernel32.GetConsoleScreenBufferInfo;
 import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
 import static org.fusesource.jansi.internal.Kernel32.SMALL_RECT;
-import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.STD_ERROR_HANDLE;
+import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.ScrollConsoleScreenBuffer;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleCursorPosition;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleTextAttribute;
 import static org.fusesource.jansi.internal.Kernel32.SetConsoleTitle;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
-import org.fusesource.jansi.internal.Kernel32.CONSOLE_SCREEN_BUFFER_INFO;
-import org.fusesource.jansi.internal.Kernel32.COORD;
-import org.fusesource.jansi.WindowsSupport;
-
 /**
  * A Windows ANSI escape processor, that uses JNA to access native platform
- * API's to change the console attributes (see 
+ * API's to change the console attributes (see
  * <a href="http://fusesource.github.io/jansi/documentation/native-api/index.html?org/fusesource/jansi/internal/Kernel32.html">Jansi native Kernel32</a>).
  * <p>The native library used is named <code>jansi</code> and is loaded using <a href="http://fusesource.github.io/hawtjni/">HawtJNI</a> Runtime
  * <a href="http://fusesource.github.io/hawtjni/documentation/api/index.html?org/fusesource/hawtjni/runtime/Library.html"><code>Library</code></a>
@@ -71,25 +71,25 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
     private static final short BACKGROUND_WHITE = (short) (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE);
 
     private static final short[] ANSI_FOREGROUND_COLOR_MAP = {
-            FOREGROUND_BLACK,
-            FOREGROUND_RED,
-            FOREGROUND_GREEN,
-            FOREGROUND_YELLOW,
-            FOREGROUND_BLUE,
-            FOREGROUND_MAGENTA,
-            FOREGROUND_CYAN,
-            FOREGROUND_WHITE,
+        FOREGROUND_BLACK,
+        FOREGROUND_RED,
+        FOREGROUND_GREEN,
+        FOREGROUND_YELLOW,
+        FOREGROUND_BLUE,
+        FOREGROUND_MAGENTA,
+        FOREGROUND_CYAN,
+        FOREGROUND_WHITE,
     };
 
     private static final short[] ANSI_BACKGROUND_COLOR_MAP = {
-            BACKGROUND_BLACK,
-            BACKGROUND_RED,
-            BACKGROUND_GREEN,
-            BACKGROUND_YELLOW,
-            BACKGROUND_BLUE,
-            BACKGROUND_MAGENTA,
-            BACKGROUND_CYAN,
-            BACKGROUND_WHITE,
+        BACKGROUND_BLACK,
+        BACKGROUND_RED,
+        BACKGROUND_GREEN,
+        BACKGROUND_YELLOW,
+        BACKGROUND_BLUE,
+        BACKGROUND_MAGENTA,
+        BACKGROUND_CYAN,
+        BACKGROUND_WHITE,
     };
 
     private final CONSOLE_SCREEN_BUFFER_INFO info = new CONSOLE_SCREEN_BUFFER_INFO();
@@ -168,14 +168,13 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
                 COORD topLeft2 = new COORD();
                 topLeft2.x = 0;
                 topLeft2.y = info.window.top;
-                int lengthToCursor = (info.cursorPosition.y - info.window.top) * info.size.x
-                        + info.cursorPosition.x;
+                int lengthToCursor = (info.cursorPosition.y - info.window.top) * info.size.x + info.cursorPosition.x;
                 FillConsoleOutputAttribute(console, info.attributes, lengthToCursor, topLeft2, written);
                 FillConsoleOutputCharacterW(console, ' ', lengthToCursor, topLeft2, written);
                 break;
             case ERASE_SCREEN_TO_END:
-                int lengthToEnd = (info.window.bottom - info.cursorPosition.y) * info.size.x +
-                        (info.size.x - info.cursorPosition.x);
+                int lengthToEnd = (info.window.bottom - info.cursorPosition.y) * info.size.x
+                        + (info.size.x - info.cursorPosition.x);
                 FillConsoleOutputAttribute(console, info.attributes, lengthToEnd, info.cursorPosition.copy(), written);
                 FillConsoleOutputCharacterW(console, ' ', lengthToEnd, info.cursorPosition.copy(), written);
                 break;
@@ -203,7 +202,8 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
                 break;
             case ERASE_LINE_TO_END:
                 int lengthToLastCol = info.size.x - info.cursorPosition.x;
-                FillConsoleOutputAttribute(console, info.attributes, lengthToLastCol, info.cursorPosition.copy(), written);
+                FillConsoleOutputAttribute(
+                        console, info.attributes, lengthToLastCol, info.cursorPosition.copy(), written);
                 FillConsoleOutputCharacterW(console, ' ', lengthToLastCol, info.cursorPosition.copy(), written);
                 break;
             default:
@@ -345,8 +345,8 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
                 applyAttribute();
                 break;
 
-            // Yeah, setting the background intensity is not underlining.. but it's best we can do
-            // using the Windows console API
+                // Yeah, setting the background intensity is not underlining.. but it's best we can do
+                // using the Windows console API
             case ATTRIBUTE_UNDERLINE:
                 info.attributes = (short) (info.attributes | BACKGROUND_INTENSITY);
                 applyAttribute();
@@ -394,7 +394,7 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
         scroll.top = info.cursorPosition.y;
         COORD org = new COORD();
         org.x = 0;
-        org.y = (short)(info.cursorPosition.y + optionInt);
+        org.y = (short) (info.cursorPosition.y + optionInt);
         CHAR_INFO info = new CHAR_INFO();
         info.attributes = originalColors;
         info.unicodeChar = ' ';
@@ -410,7 +410,7 @@ public final class WindowsAnsiProcessor extends AnsiProcessor {
         scroll.top = info.cursorPosition.y;
         COORD org = new COORD();
         org.x = 0;
-        org.y = (short)(info.cursorPosition.y - optionInt);
+        org.y = (short) (info.cursorPosition.y - optionInt);
         CHAR_INFO info = new CHAR_INFO();
         info.attributes = originalColors;
         info.unicodeChar = ' ';

--- a/src/main/java/org/fusesource/jansi/io/WindowsAnsiProcessor.java
+++ b/src/main/java/org/fusesource/jansi/io/WindowsAnsiProcessor.java
@@ -51,8 +51,6 @@ import static org.fusesource.jansi.internal.Kernel32.SetConsoleTitle;
  * <a href="http://fusesource.github.io/hawtjni/documentation/api/index.html?org/fusesource/hawtjni/runtime/Library.html"><code>Library</code></a>
  *
  * @since 1.19
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- * @author Joris Kuipers
  */
 public final class WindowsAnsiProcessor extends AnsiProcessor {
 

--- a/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
+++ b/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 /**
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class AnsiConsoleExample {
 

--- a/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
+++ b/src/test/java/org/fusesource/jansi/AnsiConsoleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,13 @@ import java.io.IOException;
  */
 public class AnsiConsoleExample {
 
-    private AnsiConsoleExample() {
-    }
+    private AnsiConsoleExample() {}
 
     public static void main(String[] args) throws IOException {
         String file = "src/test/resources/jansi.ans";
-        if (args.length > 0)
-            file = args[0];
+        if (args.length > 0) file = args[0];
 
-        // Allows us to disable ANSI processing. 
+        // Allows us to disable ANSI processing.
         if ("true".equals(System.getProperty("jansi", "true"))) {
             AnsiConsole.systemInstall();
         }
@@ -44,5 +42,4 @@ public class AnsiConsoleExample {
         }
         f.close();
     }
-
 }

--- a/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
+++ b/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
@@ -22,7 +22,6 @@ import static org.fusesource.jansi.Ansi.*;
 
 /**
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class AnsiConsoleExample2 {
 

--- a/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
+++ b/src/test/java/org/fusesource/jansi/AnsiConsoleExample2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,13 @@ import static org.fusesource.jansi.Ansi.*;
  */
 public class AnsiConsoleExample2 {
 
-    private AnsiConsoleExample2() {
-    }
+    private AnsiConsoleExample2() {}
 
     public static void main(String[] args) throws IOException {
         String file = "src/test/resources/jansi.ans";
-        if (args.length > 0)
-            file = args[0];
+        if (args.length > 0) file = args[0];
 
-        // Allows us to disable ANSI processing. 
+        // Allows us to disable ANSI processing.
         if ("true".equals(System.getProperty("jansi", "true"))) {
             AnsiConsole.systemInstall();
         }
@@ -49,5 +47,4 @@ public class AnsiConsoleExample2 {
         f.close();
         System.out.println("=======================================================================");
     }
-
 }

--- a/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,11 +80,18 @@ public class AnsiRendererTest {
     public void testRender4() {
         String str = render("@|bold,red foo bar baz|@ ick @|bold,red foo bar baz|@");
         System.out.println(str);
-        assertEquals(ansi()
-                .a(INTENSITY_BOLD).fg(RED).a("foo bar baz").reset()
-                .a(" ick ")
-                .a(INTENSITY_BOLD).fg(RED).a("foo bar baz").reset()
-                .toString(), str);
+        assertEquals(
+                ansi().a(INTENSITY_BOLD)
+                        .fg(RED)
+                        .a("foo bar baz")
+                        .reset()
+                        .a(" ick ")
+                        .a(INTENSITY_BOLD)
+                        .fg(RED)
+                        .a("foo bar baz")
+                        .reset()
+                        .toString(),
+                str);
     }
 
     @Test
@@ -94,7 +101,6 @@ public class AnsiRendererTest {
         System.out.println(str);
         assertEquals(ansi().a(INTENSITY_BOLD).a("Hello").reset().toString(), str);
     }
-
 
     @Test
     public void testRenderNothing() {

--- a/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
@@ -24,6 +24,7 @@ import static org.fusesource.jansi.Ansi.Color.*;
 import static org.fusesource.jansi.AnsiRenderer.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -32,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
 public class AnsiRendererTest {
-
     @BeforeAll
     static void setUp() {
         Ansi.setEnabled(true);
@@ -95,7 +95,6 @@ public class AnsiRendererTest {
         assertEquals(ansi().a(INTENSITY_BOLD).a("Hello").reset().toString(), str);
     }
 
-
     @Test
     public void testRenderNothing() {
         assertEquals("foo", render("foo"));
@@ -105,6 +104,11 @@ public class AnsiRendererTest {
     public void testRenderInvalidMissingEnd() {
         String str = render("@|bold foo");
         assertEquals("@|bold foo", str);
+    }
+
+    @Test
+    public void testRenderInvalidEndBeforeStart() {
+        assertThrows(IllegalArgumentException.class, () -> render("@|@"));
     }
 
     @Test

--- a/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiRendererTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for the {@link AnsiRenderer} class.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
 public class AnsiRendererTest {
 

--- a/src/test/java/org/fusesource/jansi/AnsiStringTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class AnsiStringTest {
 
     @Test
     public void testCursorPosition() {
-        Ansi ansi = Ansi.ansi().cursor( 3, 6 ).reset();
+        Ansi ansi = Ansi.ansi().cursor(3, 6).reset();
         assertEquals("\u001B[3;6H\u001B[m", ansi.toString());
     }
 }

--- a/src/test/java/org/fusesource/jansi/AnsiStringTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiStringTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
 public class AnsiStringTest {
 

--- a/src/test/java/org/fusesource/jansi/AnsiTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests for the {@link Ansi} class.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  */
 public class AnsiTest {
     @Test

--- a/src/test/java/org/fusesource/jansi/AnsiTest.java
+++ b/src/test/java/org/fusesource/jansi/AnsiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,11 +57,15 @@ public class AnsiTest {
 
     @Test
     public void testApply() {
-        assertEquals("test", Ansi.ansi().apply(new Ansi.Consumer() {
-            public void apply(Ansi ansi) {
-                ansi.a("test");
-            }
-        }).toString());
+        assertEquals(
+                "test",
+                Ansi.ansi()
+                        .apply(new Ansi.Consumer() {
+                            public void apply(Ansi ansi) {
+                                ansi.a("test");
+                            }
+                        })
+                        .toString());
     }
 
     @ParameterizedTest
@@ -143,7 +147,18 @@ public class AnsiTest {
     public void testColorDisabled() {
         Ansi.setEnabled(false);
         try {
-            assertEquals("test", Ansi.ansi().fg(32).a("t").fgRgb(0).a("e").bg(24).a("s").bgRgb(100).a("t").toString());
+            assertEquals(
+                    "test",
+                    Ansi.ansi()
+                            .fg(32)
+                            .a("t")
+                            .fgRgb(0)
+                            .a("e")
+                            .bg(24)
+                            .a("s")
+                            .bgRgb(100)
+                            .a("t")
+                            .toString());
         } finally {
             Ansi.setEnabled(true);
         }

--- a/src/test/java/org/fusesource/jansi/EncodingTest.java
+++ b/src/test/java/org/fusesource/jansi/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,11 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.Test;
-
 import org.fusesource.jansi.io.AnsiOutputStream;
 import org.fusesource.jansi.io.AnsiProcessor;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 public class EncodingTest {
 
@@ -35,12 +33,25 @@ public class EncodingTest {
     public void testEncoding8859() throws UnsupportedEncodingException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final AtomicReference<String> newLabel = new AtomicReference<String>();
-        PrintStream ansi = new AnsiPrintStream(new AnsiOutputStream(baos, null, AnsiMode.Default, new AnsiProcessor(baos) {
-            @Override
-            protected void processChangeWindowTitle(String label) {
-                newLabel.set(label);
-            }
-        }, AnsiType.Emulation, AnsiColors.TrueColor, Charset.forName("ISO-8859-1"), null, null, false), true, "ISO-8859-1");
+        PrintStream ansi = new AnsiPrintStream(
+                new AnsiOutputStream(
+                        baos,
+                        null,
+                        AnsiMode.Default,
+                        new AnsiProcessor(baos) {
+                            @Override
+                            protected void processChangeWindowTitle(String label) {
+                                newLabel.set(label);
+                            }
+                        },
+                        AnsiType.Emulation,
+                        AnsiColors.TrueColor,
+                        Charset.forName("ISO-8859-1"),
+                        null,
+                        null,
+                        false),
+                true,
+                "ISO-8859-1");
 
         ansi.print("\033]0;un bon café\007");
         ansi.flush();
@@ -51,16 +62,28 @@ public class EncodingTest {
     public void testEncodingUtf8() throws UnsupportedEncodingException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final AtomicReference<String> newLabel = new AtomicReference<String>();
-        PrintStream ansi = new PrintStream(new AnsiOutputStream(baos, null, AnsiMode.Default, new AnsiProcessor(baos) {
-            @Override
-            protected void processChangeWindowTitle(String label) {
-                newLabel.set(label);
-            }
-        }, AnsiType.Emulation, AnsiColors.TrueColor, Charset.forName("UTF-8"), null, null, false), true, "UTF-8");
+        PrintStream ansi = new PrintStream(
+                new AnsiOutputStream(
+                        baos,
+                        null,
+                        AnsiMode.Default,
+                        new AnsiProcessor(baos) {
+                            @Override
+                            protected void processChangeWindowTitle(String label) {
+                                newLabel.set(label);
+                            }
+                        },
+                        AnsiType.Emulation,
+                        AnsiColors.TrueColor,
+                        Charset.forName("UTF-8"),
+                        null,
+                        null,
+                        false),
+                true,
+                "UTF-8");
 
         ansi.print("\033]0;ひらがな\007");
         ansi.flush();
         assertEquals("ひらがな", newLabel.get());
     }
-
 }

--- a/src/test/java/org/fusesource/jansi/InstallUninstallTest.java
+++ b/src/test/java/org/fusesource/jansi/InstallUninstallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ public class InstallUninstallTest {
         print(System.out, "magna aliqua.");
         print(System.err, "Ut enim ad ");
     }
+
     private static void print(PrintStream stream, String text) {
         int half = text.length() / 2;
         stream.print(text.substring(0, half));

--- a/src/test/java/org/fusesource/jansi/WindowsSupportTest.java
+++ b/src/test/java/org/fusesource/jansi/WindowsSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2019 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/fusesource/jansi/internal/JansiLoaderTest.java
+++ b/src/test/java/org/fusesource/jansi/internal/JansiLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/fusesource/jansi/io/AnsiOutputStreamTest.java
+++ b/src/test/java/org/fusesource/jansi/io/AnsiOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 the original author(s).
+ * Copyright (C) 2009-2023 the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.fusesource.jansi.io;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
 import org.fusesource.jansi.AnsiColors;
 import org.fusesource.jansi.AnsiMode;
 import org.fusesource.jansi.AnsiType;
 import org.junit.jupiter.api.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.Charset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -31,10 +31,19 @@ class AnsiOutputStreamTest {
     @Test
     void canHandleSgrsWithMultipleOptions() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final AnsiOutputStream ansiOutput = new AnsiOutputStream(baos, null, AnsiMode.Strip, null, AnsiType.Emulation,
-                AnsiColors.TrueColor, Charset.forName("UTF-8"), null, null, false);
-        ansiOutput.write(("\u001B[33mbanana_1  |\u001B[0m 19:59:14.353\u001B[0;38m [debug] A message\u001B[0m\n").getBytes());
+        final AnsiOutputStream ansiOutput = new AnsiOutputStream(
+                baos,
+                null,
+                AnsiMode.Strip,
+                null,
+                AnsiType.Emulation,
+                AnsiColors.TrueColor,
+                Charset.forName("UTF-8"),
+                null,
+                null,
+                false);
+        ansiOutput.write(
+                ("\u001B[33mbanana_1  |\u001B[0m 19:59:14.353\u001B[0;38m [debug] A message\u001B[0m\n").getBytes());
         assertEquals("banana_1  | 19:59:14.353 [debug] A message\n", baos.toString());
     }
-
 }


### PR DESCRIPTION
This fixes a possible unwrapped StringIndexOutOfBoundException in src/main/java/org/fusesource/jansi/AnsiRenderer.java.

In [line 85](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L85), [line 95](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L95) and [line 101](https://github.com/arthurscchan/jansi/blob/master/src/main/java/org/fusesource/jansi/AnsiRenderer.java#L101) of the AnsiRenderer class. The method tries to determine the necessary index j and k for doing a substring operation on the input string. If the input string is malformed, it could cause j larger than k and result in StringIndexOutOfBoundException. For example, if the EndToken appears before the BeginToken, or there is no EndToken in the input string, then j is larger than k for sure.

This PR fixes the bug by adding a conditional check before doing the substring to ensure k is larger or equals to j. Otherwise, the input string is considered as malformed and an IllegalArgumentException is thrown.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated jansi (https://github.com/google/oss-fuzz/pull/10705). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go in details and also set up things so you can receive emails and detailed reports when bugs are found.
